### PR TITLE
Add clock & weather widget

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -214,3 +214,65 @@ body {
 .links a.xiaomi-enthusiasts {
 
 }
+
+/* Clock and Weather block */
+.info-block {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 80px;
+}
+
+.clock-time {
+    font-size: 32px;
+    font-weight: bold;
+    line-height: 1;
+}
+
+.clock-date {
+    font-size: 12px;
+    opacity: 0.7;
+}
+
+.weather-area {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+.weather-current {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.weather-icon {
+    width: 32px;
+    height: 32px;
+}
+
+.weather-temp {
+    font-size: 18px;
+    font-weight: 500;
+}
+
+.weather-forecast {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.weather-forecast .hour {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-size: 10px;
+}
+
+.weather-forecast .hour img {
+    width: 20px;
+    height: 20px;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -220,13 +220,14 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    min-height: 80px;
+    height: 153px;
 }
 
 .clock-time {
-    font-size: 32px;
+    font-size: 64px;
     font-weight: bold;
     line-height: 1;
+    font-family: "Courier New", monospace;
 }
 
 .clock-date {
@@ -239,6 +240,20 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+}
+
+.weather-location {
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 4px;
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
 }
 
 .weather-current {

--- a/css/main.css
+++ b/css/main.css
@@ -227,7 +227,7 @@ body {
     font-size: 64px;
     font-weight: bold;
     line-height: 1;
-    font-family: "Courier New", monospace;
+    font-family: "Orbitron", sans-serif;
 }
 
 .clock-date {
@@ -264,13 +264,13 @@ body {
 }
 
 .weather-icon {
-    width: 32px;
-    height: 32px;
+    width: 48px;
+    height: 48px;
 }
 
 .weather-temp {
-    font-size: 18px;
-    font-weight: 500;
+    font-size: 24px;
+    font-weight: 600;
 }
 
 .weather-forecast {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,19 @@
   <body>
     <div class="settings-overlay" id="settingsOverlay"></div>
     <div class="wrapper">
+      <div id="infoBlock" class="section info-block">
+        <div class="clock-area">
+          <div id="clockTime" class="clock-time"></div>
+          <div id="clockDate" class="clock-date"></div>
+        </div>
+        <div class="weather-area">
+          <div id="weatherCurrent" class="weather-current">
+            <img id="weatherIcon" class="weather-icon" alt="weather" />
+            <span id="weatherTemp" class="weather-temp"></span>
+          </div>
+          <div id="weatherForecast" class="weather-forecast"></div>
+        </div>
+      </div>
       <div id="sections"></div>
       <div class="settings-panel" id="settingsPanel"></div>
       <div class="footer">
@@ -217,6 +230,66 @@
           renderSections();
         };
 
+        // Update clock display
+        const updateClock = () => {
+          const now = new Date();
+          const timeStr = now.toLocaleTimeString('ru-RU', {
+            hour: '2-digit',
+            minute: '2-digit',
+          });
+          const dateStr = now.toLocaleDateString('ru-RU', {
+            day: 'numeric',
+            month: 'long',
+            weekday: 'long',
+          });
+          document.getElementById('clockTime').textContent = timeStr;
+          document.getElementById('clockDate').textContent = dateStr;
+        };
+
+        // Map weather data to DOM
+        const updateWeather = (data) => {
+          const current = data.current_weather;
+          const hourlyTimes = data.hourly.time;
+          const tempArr = data.hourly.temperature_2m;
+          const codeArr = data.hourly.weathercode;
+
+          document.getElementById('weatherTemp').textContent =
+            Math.round(current.temperature) + '°';
+          document.getElementById('weatherIcon').src =
+            `https://open-meteo.com/images/weather-icons/${current.weathercode}.png`;
+
+          const nowIndex = hourlyTimes.indexOf(current.time);
+          let forecastHTML = '';
+          for (let i = 1; i <= 12; i++) {
+            const idx = nowIndex + i;
+            if (idx >= hourlyTimes.length) break;
+            const date = new Date(hourlyTimes[idx]);
+            const time = date.toLocaleTimeString('ru-RU', { hour: '2-digit' });
+            const t = Math.round(tempArr[idx]);
+            const code = codeArr[idx];
+            forecastHTML += `<div class="hour"><img src="https://open-meteo.com/images/weather-icons/${code}.png" alt=""/><span>${time}</span><span>${t}°</span></div>`;
+          }
+          document.getElementById('weatherForecast').innerHTML = forecastHTML;
+        };
+
+        const fetchWeather = (lat, lon) => {
+          const url =
+            `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=temperature_2m,weathercode&forecast_days=1&timezone=Europe%2FMoscow`;
+          fetch(url)
+            .then((r) => r.json())
+            .then(updateWeather)
+            .catch((e) => console.error('Weather error', e));
+        };
+
+        const initWeather = () => {
+          if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(
+              (pos) => fetchWeather(pos.coords.latitude, pos.coords.longitude),
+              (err) => console.error('Geolocation error', err),
+            );
+          }
+        };
+
         // Change the order of services by moving an element up or down
         const moveService = (id, direction) => {
           let order = loadOrder();
@@ -237,6 +310,9 @@
         const initializeInterface = () => {
           renderSections();
           renderSettings();
+          updateClock();
+          setInterval(updateClock, 60000);
+          initWeather();
         };
 
         // Expose functions to the global scope for inline event handlers

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <title>Xiaomi DeepLink Entry</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&display=swap" rel="stylesheet" />
     <link href="css/main.css?v=202504130359" rel="stylesheet" />
     <script src="data/services.js?v=202504130359"></script>
   </head>
@@ -297,23 +298,27 @@
 
           const nowIndex = hourlyTimes.indexOf(current.time);
           let forecastHTML = '';
-          for (let i = 1; i <= 12; i++) {
-            const idx = nowIndex + i;
-            if (idx >= hourlyTimes.length) break;
+          const OFFSETS = [3, 6, 12, 24];
+          OFFSETS.forEach((hrs) => {
+            const idx = nowIndex + hrs;
+            if (idx >= hourlyTimes.length) return;
             const date = new Date(hourlyTimes[idx]);
-            const time = date.toLocaleTimeString('ru-RU', { hour: '2-digit' });
-            const t = Math.round(tempArr[idx]);
+            const time = date.toLocaleTimeString('ru-RU', {
+              hour: '2-digit',
+              minute: '2-digit',
+            });
+            const t = Math.floor(tempArr[idx]);
             const code = codeArr[idx];
             const icon = ICON_MAP[code];
             const name = icon ? icon.day : '0d';
             forecastHTML += `<div class="hour"><img src="https://raw.githubusercontent.com/engperini/open-meteo-icons/main/icons/${name}.png" alt=""/><span>${time}</span><span>${t}°</span></div>`;
-          }
+          });
           document.getElementById('weatherForecast').innerHTML = forecastHTML;
         };
 
         const fetchWeather = (lat, lon) => {
           const url =
-            `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=temperature_2m,weathercode&forecast_days=1&timezone=Europe%2FMoscow`;
+            `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=temperature_2m,weathercode&forecast_days=2&timezone=auto`;
           fetch(url)
             .then((r) => r.json())
             .then(updateWeather)

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
           <div id="clockDate" class="clock-date"></div>
         </div>
         <div class="weather-area">
+          <div id="weatherLocation" class="weather-location">
+            <span id="locationDot" class="status-dot"></span>
+            <span id="weatherPlace"></span>
+          </div>
           <div id="weatherCurrent" class="weather-current">
             <img id="weatherIcon" class="weather-icon" alt="weather" />
             <span id="weatherTemp" class="weather-temp"></span>
@@ -247,16 +251,49 @@
         };
 
         // Map weather data to DOM
+        const ICON_MAP = {
+          0: { day: "0d", night: "0n" },
+          1: { day: "1d", night: "1n" },
+          2: { day: "2d", night: "2n" },
+          3: { day: "3d", night: "3n" },
+          45: { day: "45d", night: "45n" },
+          48: { day: "48d", night: "48n" },
+          51: { day: "51d", night: "51n" },
+          53: { day: "53d", night: "53n" },
+          55: { day: "55d", night: "55n" },
+          56: { day: "56d", night: "56n" },
+          57: { day: "57d", night: "57n" },
+          61: { day: "61d", night: "61n" },
+          63: { day: "63d", night: "63n" },
+          65: { day: "65d", night: "65n" },
+          66: { day: "66d", night: "66n" },
+          67: { day: "67d", night: "67n" },
+          71: { day: "71d", night: "71n" },
+          73: { day: "73d", night: "73n" },
+          75: { day: "75d", night: "75n" },
+          77: { day: "77d", night: "77n" },
+          80: { day: "80d", night: "80n" },
+          81: { day: "81d", night: "81n" },
+          82: { day: "82d", night: "82n" },
+          85: { day: "85d", night: "85n" },
+          86: { day: "86d", night: "86n" },
+          95: { day: "95d", night: "95n" },
+          96: { day: "96d", night: "96n" },
+          99: { day: "99d", night: "99n" },
+        };
+
         const updateWeather = (data) => {
           const current = data.current_weather;
           const hourlyTimes = data.hourly.time;
           const tempArr = data.hourly.temperature_2m;
           const codeArr = data.hourly.weathercode;
 
-          document.getElementById('weatherTemp').textContent =
-            Math.round(current.temperature) + '°';
-          document.getElementById('weatherIcon').src =
-            `https://open-meteo.com/images/weather-icons/${current.weathercode}.png`;
+          document.getElementById("weatherTemp").textContent =
+            Math.round(current.temperature) + "°";
+          const curIcon = ICON_MAP[current.weathercode];
+          const curName = curIcon ? (current.is_day ? curIcon.day : curIcon.night) : "0d";
+          document.getElementById("weatherIcon").src =
+            `https://raw.githubusercontent.com/engperini/open-meteo-icons/main/icons/${curName}.png`;
 
           const nowIndex = hourlyTimes.indexOf(current.time);
           let forecastHTML = '';
@@ -267,7 +304,9 @@
             const time = date.toLocaleTimeString('ru-RU', { hour: '2-digit' });
             const t = Math.round(tempArr[idx]);
             const code = codeArr[idx];
-            forecastHTML += `<div class="hour"><img src="https://open-meteo.com/images/weather-icons/${code}.png" alt=""/><span>${time}</span><span>${t}°</span></div>`;
+            const icon = ICON_MAP[code];
+            const name = icon ? icon.day : '0d';
+            forecastHTML += `<div class="hour"><img src="https://raw.githubusercontent.com/engperini/open-meteo-icons/main/icons/${name}.png" alt=""/><span>${time}</span><span>${t}°</span></div>`;
           }
           document.getElementById('weatherForecast').innerHTML = forecastHTML;
         };
@@ -281,12 +320,55 @@
             .catch((e) => console.error('Weather error', e));
         };
 
+        const updateLocation = (name, color) => {
+          document.getElementById('weatherPlace').textContent = name;
+          document.getElementById('locationDot').style.backgroundColor = color;
+        };
+
+        const fetchLocationName = async (lat, lon) => {
+          try {
+            const resp = await fetch(
+              `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=jsonv2`
+            );
+            const data = await resp.json();
+            const addr = data.address || {};
+            return (
+              addr.city ||
+              addr.town ||
+              addr.village ||
+              addr.county ||
+              ''
+            );
+          } catch (e) {
+            console.error('Reverse geocode error', e);
+            return '';
+          }
+        };
+
         const initWeather = () => {
+          const useMoscow = () => {
+            const lat = 55.7558;
+            const lon = 37.6176;
+            updateLocation('Moscow', 'orange');
+            fetchWeather(lat, lon);
+          };
+
           if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition(
-              (pos) => fetchWeather(pos.coords.latitude, pos.coords.longitude),
-              (err) => console.error('Geolocation error', err),
+              async (pos) => {
+                const lat = pos.coords.latitude;
+                const lon = pos.coords.longitude;
+                const name = await fetchLocationName(lat, lon);
+                updateLocation(name, 'limegreen');
+                fetchWeather(lat, lon);
+              },
+              () => {
+                console.error('Geolocation error');
+                useMoscow();
+              }
             );
+          } else {
+            useMoscow();
           }
         };
 


### PR DESCRIPTION
## Summary
- add clock and weather block at top of the page
- fetch weather from Open‑Meteo using geolocation
- show 12‑hour forecast with icons
- style clock and weather widget

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684586f33a7c8321976ba0aeb8bf766b