### PR TITLE
Fix forecast icons day/night handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,11 +283,12 @@
           99: { day: "99d", night: "99n" },
         };
 
-        const updateWeather = (data) => {
-          const current = data.current_weather;
-          const hourlyTimes = data.hourly.time;
-          const tempArr = data.hourly.temperature_2m;
-          const codeArr = data.hourly.weathercode;
+          const updateWeather = (data) => {
+            const current = data.current_weather;
+            const hourlyTimes = data.hourly.time;
+            const tempArr = data.hourly.temperature_2m;
+            const codeArr = data.hourly.weathercode;
+            const dayArr = data.hourly.is_day || [];
 
           document.getElementById("weatherTemp").textContent = Math.round(current.temperature) + "°";
           const curIcon = ICON_MAP[current.weathercode];
@@ -296,7 +297,8 @@
             `https://raw.githubusercontent.com/engperini/open-meteo-icons/main/icons/${curName}.png`;
           document.getElementById("weatherIcon").style.display = "block"
 
-          const nowIndex = hourlyTimes.indexOf(current.time);
+          const hourKey = current.time.slice(0, 13) + ':00';
+          const nowIndex = hourlyTimes.indexOf(hourKey);
           let forecastHTML = '';
           const OFFSETS = [3, 6, 12, 24];
           OFFSETS.forEach((hrs) => {
@@ -310,7 +312,8 @@
             const t = Math.floor(tempArr[idx]);
             const code = codeArr[idx];
             const icon = ICON_MAP[code];
-            const name = icon ? icon.day : '0d';
+            const isDay = dayArr[idx] === 1;
+            const name = icon ? (isDay ? icon.day : icon.night) : '0d';
             forecastHTML += `<div class="hour"><img src="https://raw.githubusercontent.com/engperini/open-meteo-icons/main/icons/${name}.png" alt=""/><span>${time}</span><span>${t}°</span></div>`;
           });
           document.getElementById('weatherForecast').innerHTML = forecastHTML;
@@ -318,7 +321,7 @@
 
         const fetchWeather = (lat, lon) => {
           const url =
-            `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=temperature_2m,weathercode&forecast_days=2&timezone=auto`;
+            `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=temperature_2m,weathercode,is_day&forecast_days=2&timezone=auto`;
           fetch(url)
             .then((r) => r.json())
             .then(updateWeather)


### PR DESCRIPTION
## Summary
- use `is_day` from the API for future weather icons
- fall back to the current hour when finding the forecast index
- request `is_day` data in the weather fetch

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849efeaf4788321a05412595eb6b017